### PR TITLE
Detect dragonfly as a BSD variant

### DIFF
--- a/id_bsd.go
+++ b/id_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd netbsd openbsd
+// +build freebsd netbsd openbsd dragonfly
 
 package machineid
 


### PR DESCRIPTION
This adds `dragonfly` as a build variant for BSD. 