### PR TITLE
support for cron on darwin os

### DIFF
--- a/id_darwin_test.go
+++ b/id_darwin_test.go
@@ -64,3 +64,13 @@ func Test_machineID(t *testing.T) {
 		t.Error("Got empty machine id")
 	}
 }
+
+func Test_runIoreg(t *testing.T) {
+	got, err := runIoreg(true)
+	if err != nil {
+		t.Error(err)
+	}
+	if got.String() == "" {
+		t.Error("Got empty machine id when using absolute ioreg path")
+	}
+}


### PR DESCRIPTION
When run under cron, `machineID` returns error:
```
exec: \"ioreg\": executable file not found in $PATH
```

This PR makes it will try again with absolute path instead of failing.
I was able to figure out thanks to: [crontab-doesnt-execute-ioreg-on-my-mac](https://stackoverflow.com/questions/25622613/crontab-doesnt-execute-ioreg-on-my-mac)