### PR TITLE
Add support for AIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ All machine IDs are usually generated during system installation and stay consta
 
 The following sources are used:
 
+* **AIX** uses the OS (or WPAR if applicable) UUID from the `os_uuid` attribute
 * **BSD** uses `/etc/hostid` and `smbios.system.uuid` as a fallback
 * **Linux** uses `/var/lib/dbus/machine-id` ([man](http://man7.org/linux/man-pages/man5/machine-id.5.html))
 * **OS X** uses `IOPlatformUUID`
@@ -140,6 +141,13 @@ hashedID, err := machineid.ProtectedID("myAppName")
 ## Snippets
 
 Don't want to download code, and just need a way to get the data by yourself?
+
+
+AIX:
+
+```bash
+lsattr -l sys0 -a os_uuid -E | cut -f 2 -d ' '
+```
 
 BSD:
 

--- a/id_aix.go
+++ b/id_aix.go
@@ -1,0 +1,20 @@
+// +build aix
+
+package machineid
+
+import (
+	"bytes"
+	"os"
+	"strings"
+)
+
+// machineID returns the operating system uuid set in the kernel or WPAR uuid if
+// applicable.
+func machineID() (string, error) {
+	buf := &bytes.Buffer{}
+	err := run(buf, os.Stderr, "lsattr", "-l", "sys0", "-a", "os_uuid","-E")
+	if err != nil {
+		return "", err
+	}
+	return strings.Split(buf.String()," ")[1], nil
+}


### PR DESCRIPTION
Add a basic implementation for AIX using `os_uuid` attribute.